### PR TITLE
[ 不具合修正 ] ブロックエディタ iframe での Font Awesome CSS 読み込み警告を修正

### DIFF
--- a/src/VkFontAwesomeVersions.php
+++ b/src/VkFontAwesomeVersions.php
@@ -422,23 +422,26 @@ class VkFontAwesomeVersions {
 	}
 
 	/**
-	 * Load Font Awesome CSS for block editor.
+	 * Load Font Awesome CSS for block editor (iframe).
+	 *
+	 * WP 6.3+ のブロックエディタは iframe で描画されるため、
+	 * enqueue_block_assets フック経由で正しくスタイルを追加する必要がある。
+	 * is_admin() チェックを外し、ハンドル名をフロントエンド側の
+	 * load_font_awesome() と統一することで、フロントエンドでは
+	 * WordPress のデデュプリケーションにより二重読み込みを防止する。
 	 *
 	 * @return void
 	 */
 	public static function load_gutenberg_font_awesome() {
-		if ( ! is_admin() ) {
-			return;
-		}
 		$current_info = self::current_info();
-		$options = self::get_option_fa();
-		wp_enqueue_style( 'gutenberg-font-awesome', $current_info['url_css'], array(), $current_info['version'] );
+		$options      = self::get_option_fa();
+		wp_enqueue_style( 'vk-font-awesome', $current_info['url_css'], array(), $current_info['version'] );
 		if ( ! empty( $options['compatibility']['v4'] ) ) {
-			wp_enqueue_style( 'gutenberg-font-awesome-v4-shims', $current_info['url_v4-shims_css'], array( 'gutenberg-font-awesome' ), $current_info['version'] );
-			wp_enqueue_style( 'gutenberg-font-awesome-v4-font-face', $current_info['url_v4-font-face_css'], array( 'gutenberg-font-awesome' ), $current_info['version'] );
+			wp_enqueue_style( 'vk-font-awesome-v4-shims', $current_info['url_v4-shims_css'], array( 'vk-font-awesome' ), $current_info['version'] );
+			wp_enqueue_style( 'vk-font-awesome-v4-font-face', $current_info['url_v4-font-face_css'], array( 'vk-font-awesome' ), $current_info['version'] );
 		}
 		if ( ! empty( $options['compatibility']['v5'] ) ) {
-			wp_enqueue_style( 'gutenberg-font-awesome-v5-font-face', $current_info['url_v5-font-face_css'], array( 'gutenberg-font-awesome' ), $current_info['version'] );
+			wp_enqueue_style( 'vk-font-awesome-v5-font-face', $current_info['url_v5-font-face_css'], array( 'vk-font-awesome' ), $current_info['version'] );
 		}
 	}
 


### PR DESCRIPTION
## 概要

WordPress 6.3+ のブロックエディタで以下のコンソール警告が表示される問題を修正しました：

```
gutenberg-font-awesome-css was added to the iframe incorrectly.
Please use block.json or enqueue_block_assets to add styles to the iframe.
```

## 原因

`load_gutenberg_font_awesome()` 内の `is_admin()` チェックにより、WP 6.3+ のブロックエディタ iframe 描画コンテキストでスタイルが正しく enqueue されず、iframe が親ページからスタイルを拾い上げることで警告が発生していました。

## 変更内容

- `is_admin()` チェックを削除
- ハンドル名を `gutenberg-font-awesome` → `vk-font-awesome` に統一（フロントエンド側の `load_font_awesome()` と同じハンドル名）
- フロントエンドでは WordPress のデデュプリケーションにより二重読み込みは発生しない

## テスト

- [ ] ブロックエディタでコンソール警告が出ないこと
- [ ] ブロックエディタ内で Font Awesome アイコンが正常に表示されること
- [ ] フロントエンドで Font Awesome が正常に読み込まれること（CSS / SVG 両モード）
- [ ] クラシックエディタで Font Awesome が正常に動作すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* ブロックエディタでFont Awesomeアイコンが常に正しく読み込まれるようになりました。エディタ内での利用時に、すべてのFont Awesomeバージョン（v4、v5を含む）との互換性が確保されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->