### PR TITLE
[ 開発環境 ] font-awesome-versions テストをリリース時と run-ci ラベル付き PR のみ実行に変更

### DIFF
--- a/.github/workflows/php_unit.yml
+++ b/.github/workflows/php_unit.yml
@@ -1,18 +1,17 @@
 name: Build Check & PHPUnit
 
 on:
-    push:
-        branches:
-            - master
     pull_request:
         branches:
             - master
             - develop
             - ^feature/.+
+        types: [opened, reopened, labeled, synchronize]
 
 jobs:
     php_unit:
         name: php unittest
+        if: contains(github.event.pull_request.labels.*.name, 'run-ci')
         runs-on: ubuntu-latest
         strategy:
             matrix:


### PR DESCRIPTION
## 概要
GitHub Actions の消費削減のため、PHPUnit テストを push トリガー廃止・`run-ci` ラベル付き PR のときのみ実行するように変更しました。

## 変更内容
- `.github/workflows/php_unit.yml`
  - `on.push`（master）トリガーを削除
  - `on.pull_request` に `types: [opened, reopened, labeled, synchronize]` を追加
  - `php_unit` ジョブに `if: contains(github.event.pull_request.labels.*.name, 'run-ci')` を追加（9 ジョブ matrix を run-ci ラベル付き時のみ実行）

## 確認手順
1. ラベル無しの PR ではテストワークフローが起動しないこと
2. `run-ci` ラベルを付与するとテストワークフローが起動すること
3. push（ブランチへの push）ではテストワークフローが起動しないこと
4. リリース時（該当する場合）は従来どおりテストが実行されること

CI 設定のみの変更でプラグイン動作に影響はありません。

関連: vektor-inc/multi-repo-tasks#24
