### PR TITLE
[ 不具合修正 ] Font Awesome の旧バージョン設定が残っていると Fatal Error で画面全体が表示不能になる不具合を修正

### DIFF
--- a/src/VkFontAwesomeVersions.php
+++ b/src/VkFontAwesomeVersions.php
@@ -263,14 +263,17 @@ class VkFontAwesomeVersions {
 	 */
 	public static function get_option_fa() {
 
+		// 既定値は複数の分岐で使うため、一度だけ算出して使い回す（get_option_default() は apply_filters 経由のため）。
+		$default = self::get_option_default();
+
 		// 基本の保存値（実際に読み込むアセットのバージョン）
 		$version = get_option( 'vk_font_awesome_version' );
-		$options = get_option( 'vk_font_awesome_options', self::get_option_default() );
+		$options = get_option( 'vk_font_awesome_options', $default );
 
 		// 保存値が配列でない壊れた状態でも、後続の添字アクセスや書き込みで警告や Fatal を起こさないよう、
 		// マイグレーション処理より前に配列であることを保証する。
 		if ( ! is_array( $options ) ) {
-			$options = self::get_option_default();
+			$options = $default;
 		}
 
 		// 古い保存値が残っている場合のマイグレーション対応
@@ -282,7 +285,6 @@ class VkFontAwesomeVersions {
 		// version キーが無い／文字列でない・compatibility が不正など、壊れた保存値でも
 		// 後続の比較や添字アクセスで警告や Fatal を起こさないよう正規化する。
 		if ( empty( $options['version'] ) || ! is_string( $options['version'] ) ) {
-			$default            = self::get_option_default();
 			$options['version'] = $default['version'];
 		}
 		if ( ! isset( $options['compatibility'] ) || ! is_array( $options['compatibility'] ) ) {
@@ -309,6 +311,14 @@ class VkFontAwesomeVersions {
 			$options['version'] = '7_WebFonts_CSS';
 		} elseif ( '6_SVG_JS' === $options['version'] ) {
 			$options['version'] = '7_SVG_JS';
+		}
+
+		// ここまでの移行処理でも versions() に存在しないキー（不正な文字列など）が残っている場合はデフォルトへフォールバックする。
+		// get_option_fa() が常に有効なバージョンキーを返すようにし、=== 比較のみを行う呼び出し元
+		// （ex_and_link() / print_fa() / dynamic_css() / class_switch() / old_notice() 等）での未定義参照を防ぐ。
+		$valid_versions = self::versions();
+		if ( empty( $valid_versions[ $options['version'] ] ) ) {
+			$options['version'] = $default['version'];
 		}
 
 		// 保存値が存在しない場合はデフォルトをセット
@@ -449,7 +459,7 @@ class VkFontAwesomeVersions {
 			return;
 		}
 		$current_info = self::current_info();
-		$options = self::get_option_fa();
+		$options      = self::get_option_fa();
 		wp_enqueue_style( 'gutenberg-font-awesome', $current_info['url_css'], array(), $current_info['version'] );
 		if ( ! empty( $options['compatibility']['v4'] ) ) {
 			wp_enqueue_style( 'gutenberg-font-awesome-v4-shims', $current_info['url_v4-shims_css'], array( 'gutenberg-font-awesome' ), $current_info['version'] );
@@ -580,12 +590,12 @@ class VkFontAwesomeVersions {
 		$wp_customize->add_control(
 			'vk_font_awesome_options[version]',
 			array(
-				'label'       => __( 'Font Awesome Version', 'font-awesome-versions' ),
-				'section'     => 'VK Font Awesome',
-				'settings'    => 'vk_font_awesome_options[version]',
-				'type'        => 'select',
-				'priority'    => '',
-				'choices'     => $choices,
+				'label'    => __( 'Font Awesome Version', 'font-awesome-versions' ),
+				'section'  => 'VK Font Awesome',
+				'settings' => 'vk_font_awesome_options[version]',
+				'type'     => 'select',
+				'priority' => '',
+				'choices'  => $choices,
 			)
 		);
 

--- a/src/VkFontAwesomeVersions.php
+++ b/src/VkFontAwesomeVersions.php
@@ -267,17 +267,20 @@ class VkFontAwesomeVersions {
 		$version = get_option( 'vk_font_awesome_version' );
 		$options = get_option( 'vk_font_awesome_options', self::get_option_default() );
 
+		// 保存値が配列でない壊れた状態でも、後続の添字アクセスや書き込みで警告や Fatal を起こさないよう、
+		// マイグレーション処理より前に配列であることを保証する。
+		if ( ! is_array( $options ) ) {
+			$options = self::get_option_default();
+		}
+
 		// 古い保存値が残っている場合のマイグレーション対応
 		if ( ! empty( $version ) && empty( $options['version'] ) ) {
 			$options['version'] = $version;
 			delete_option( 'vk_font_awesome_version' );
 		}
 
-		// 保存値が配列でない・version キーが無い／文字列でない・compatibility が不正など、
-		// 壊れた保存値が入っていても後続の比較や添字アクセスで警告や Fatal を起こさないよう正規化する。
-		if ( ! is_array( $options ) ) {
-			$options = self::get_option_default();
-		}
+		// version キーが無い／文字列でない・compatibility が不正など、壊れた保存値でも
+		// 後続の比較や添字アクセスで警告や Fatal を起こさないよう正規化する。
 		if ( empty( $options['version'] ) || ! is_string( $options['version'] ) ) {
 			$default            = self::get_option_default();
 			$options['version'] = $default['version'];

--- a/src/VkFontAwesomeVersions.php
+++ b/src/VkFontAwesomeVersions.php
@@ -276,9 +276,13 @@ class VkFontAwesomeVersions {
 			$options = $default;
 		}
 
-		// 古い保存値が残っている場合のマイグレーション対応
-		if ( ! empty( $version ) && empty( $options['version'] ) ) {
-			$options['version'] = $version;
+		// 古い保存値（旧 vk_font_awesome_version オプション）が残っている場合のマイグレーション対応。
+		// 値は vk_font_awesome_options へ一本化するため、現在の version が空のときのみ引き継ぎ、
+		// 引き継ぎの有無にかかわらず旧オプションは常に削除して DB にスタール値を残さない。
+		if ( ! empty( $version ) ) {
+			if ( empty( $options['version'] ) ) {
+				$options['version'] = $version;
+			}
 			delete_option( 'vk_font_awesome_version' );
 		}
 

--- a/src/VkFontAwesomeVersions.php
+++ b/src/VkFontAwesomeVersions.php
@@ -459,7 +459,7 @@ class VkFontAwesomeVersions {
 			return;
 		}
 		$current_info = self::current_info();
-		$options      = self::get_option_fa();
+		$options = self::get_option_fa();
 		wp_enqueue_style( 'gutenberg-font-awesome', $current_info['url_css'], array(), $current_info['version'] );
 		if ( ! empty( $options['compatibility']['v4'] ) ) {
 			wp_enqueue_style( 'gutenberg-font-awesome-v4-shims', $current_info['url_v4-shims_css'], array( 'gutenberg-font-awesome' ), $current_info['version'] );
@@ -590,12 +590,12 @@ class VkFontAwesomeVersions {
 		$wp_customize->add_control(
 			'vk_font_awesome_options[version]',
 			array(
-				'label'    => __( 'Font Awesome Version', 'font-awesome-versions' ),
-				'section'  => 'VK Font Awesome',
-				'settings' => 'vk_font_awesome_options[version]',
-				'type'     => 'select',
-				'priority' => '',
-				'choices'  => $choices,
+				'label'       => __( 'Font Awesome Version', 'font-awesome-versions' ),
+				'section'     => 'VK Font Awesome',
+				'settings'    => 'vk_font_awesome_options[version]',
+				'type'        => 'select',
+				'priority'    => '',
+				'choices'     => $choices,
 			)
 		);
 

--- a/src/VkFontAwesomeVersions.php
+++ b/src/VkFontAwesomeVersions.php
@@ -311,19 +311,18 @@ class VkFontAwesomeVersions {
 		$versions = self::versions();
 		$option   = get_option( 'vk_font_awesome_options', self::get_option_default() );
 
-		if ( '7_WebFonts_CSS' === $option['version'] ) {
-			$option = '7_WebFonts_CSS';
-		} elseif ( '7_SVG_JS' === $option['version'] ) {
-			$option = '7_SVG_JS';
+		// 保存値は array( 'version' => ... ) 想定だが、古い保存値や誤った値が入っている場合に備えて
+		// バージョンキー（文字列）を安全に取り出す。配列のまま添字アクセスすると PHP 8 で Fatal になるため。
+		$version = is_array( $option ) && isset( $option['version'] ) ? $option['version'] : $option;
+
+		// 4/5/6 系などのレガシー値や $versions に存在しないキーが保存されている場合はデフォルト（7 系 CSS）へフォールバック。
+		// $versions は 7 系のキーのみ持つため、該当しなければデフォルトに寄せる。
+		if ( ! is_string( $version ) || empty( $versions[ $version ] ) ) {
+			$default = self::get_option_default();
+			$version = $default['version'];
 		}
 
-		// 存在しないキーが指定されても7系CSSにフォールバック
-		if ( empty( $versions[ $option ] ) ) {
-			$options = self::get_option_default();
-			$option  = $options['version'];
-		}
-
-		return $versions[ $option ];
+		return $versions[ $version ];
 	}
 
 	/**

--- a/src/VkFontAwesomeVersions.php
+++ b/src/VkFontAwesomeVersions.php
@@ -273,6 +273,19 @@ class VkFontAwesomeVersions {
 			delete_option( 'vk_font_awesome_version' );
 		}
 
+		// 保存値が配列でない・version キーが無い／文字列でない・compatibility が不正など、
+		// 壊れた保存値が入っていても後続の比較や添字アクセスで警告や Fatal を起こさないよう正規化する。
+		if ( ! is_array( $options ) ) {
+			$options = self::get_option_default();
+		}
+		if ( empty( $options['version'] ) || ! is_string( $options['version'] ) ) {
+			$default            = self::get_option_default();
+			$options['version'] = $default['version'];
+		}
+		if ( ! isset( $options['compatibility'] ) || ! is_array( $options['compatibility'] ) ) {
+			$options['compatibility'] = array();
+		}
+
 		// 4系は7系へ移行しつつ4系互換モードを有効化
 		if ( '4.7' === $options['version'] ) {
 			$options['version']             = '7_WebFonts_CSS';
@@ -309,17 +322,20 @@ class VkFontAwesomeVersions {
 	public static function current_info() {
 		// アセット読み込み用の実バージョンを算出
 		$versions = self::versions();
-		$option   = get_option( 'vk_font_awesome_options', self::get_option_default() );
+
+		// 実際に使用するバージョンは get_option_fa() の正規化結果を唯一の基準にする。
+		// これによりレガシー値（4/5/6 系）も 7 系（SVG / CSS の別を保持）へ正しく解決され、
+		// 呼び出し箇所（フロント / 管理画面 / エディタ）による差異が出ない。
+		$option = self::get_option_fa();
 
 		// 保存値は array( 'version' => ... ) 想定だが、古い保存値や誤った値が入っている場合に備えて
 		// バージョンキー（文字列）を安全に取り出す。配列のまま添字アクセスすると PHP 8 で Fatal になるため。
 		$version = is_array( $option ) && isset( $option['version'] ) ? $option['version'] : $option;
 
-		// 4/5/6 系などのレガシー値や $versions に存在しないキーが保存されている場合はデフォルト（7 系 CSS）へフォールバック。
-		// $versions は 7 系のキーのみ持つため、該当しなければデフォルトに寄せる。
+		// フィルタ等で $versions に存在しないキーが返っても未定義参照にならないよう、
+		// 確実に存在する 7 系 CSS を最終フォールバックにする（$versions は 7 系のキーのみ持つ）。
 		if ( ! is_string( $version ) || empty( $versions[ $version ] ) ) {
-			$default = self::get_option_default();
-			$version = $default['version'];
+			$version = '7_WebFonts_CSS';
 		}
 
 		return $versions[ $version ];

--- a/tests/test-vk-font-awesome-versions.php
+++ b/tests/test-vk-font-awesome-versions.php
@@ -166,6 +166,17 @@ class VkFontAwesomeVersionsTest extends WP_UnitTestCase {
 					),
 				),
 			),
+			// versions() に存在しない不正な文字列はデフォルト（7_WebFonts_CSS）へフォールバックする。
+			array(
+				'option_fa_version' => 'invalid_value',
+				'correct'           => array(
+					'version'       => '7_WebFonts_CSS',
+					'compatibility' => array(
+						'v4' => false,
+						'v5' => false,
+					),
+				),
+			),
 		);
 
 		foreach ( $tests as $key => $value ) {
@@ -276,6 +287,11 @@ class VkFontAwesomeVersionsTest extends WP_UnitTestCase {
 					'version'       => array( 'broken' ),
 					'compatibility' => array(),
 				),
+				'expected_key'        => '7_WebFonts_CSS',
+			),
+			array(
+				'test_condition_name' => '保存オプション自体が配列でなく文字列の場合 => Fatal を起こさず 7_WebFonts_CSS へフォールバック',
+				'stored'              => 'not-an-array',
 				'expected_key'        => '7_WebFonts_CSS',
 			),
 		);

--- a/tests/test-vk-font-awesome-versions.php
+++ b/tests/test-vk-font-awesome-versions.php
@@ -181,4 +181,66 @@ class VkFontAwesomeVersionsTest extends WP_UnitTestCase {
 			$this->assertEquals( $value['correct'], $return );
 		}
 	}
+
+	/**
+	 * Test current_info() method
+	 *
+	 * 保存値に 4/5/6 系などのレガシー値や不正な値が入っていても Fatal を起こさず、
+	 * デフォルト（7 系 CSS）のアセット情報へフォールバックすることを確認する。
+	 *
+	 * @return void
+	 */
+	function test_current_info() {
+		// versions() の実キー配列を基準にして期待値を組み立てる（URL は環境依存のため直書きしない）。
+		$versions = VkFontAwesomeVersions::versions();
+
+		$tests = array(
+			// 7 系 Web Fonts はそのまま 7_WebFonts_CSS のアセット情報を返す。
+			array(
+				'saved_version' => '7_WebFonts_CSS',
+				'expected_key'  => '7_WebFonts_CSS',
+			),
+			// 7 系 SVG はそのまま 7_SVG_JS のアセット情報を返す。
+			array(
+				'saved_version' => '7_SVG_JS',
+				'expected_key'  => '7_SVG_JS',
+			),
+			// レガシー値（6 系）は versions() にキーが無いためデフォルト（7_WebFonts_CSS）へフォールバックする。
+			array(
+				'saved_version' => '6_WebFonts_CSS',
+				'expected_key'  => '7_WebFonts_CSS',
+			),
+			// レガシー値（5 系）も同様にフォールバックする。
+			array(
+				'saved_version' => '5_WebFonts_CSS',
+				'expected_key'  => '7_WebFonts_CSS',
+			),
+			// レガシー値（4.7 系）も同様にフォールバックする。
+			array(
+				'saved_version' => '4.7',
+				'expected_key'  => '7_WebFonts_CSS',
+			),
+			// 未知の不正な値もフォールバックする。
+			array(
+				'saved_version' => 'invalid_value',
+				'expected_key'  => '7_WebFonts_CSS',
+			),
+		);
+
+		foreach ( $tests as $value ) {
+			// テスト対象のバージョンを保存する（current_info() は保存値を書き換えない読み取り専用のため、この値がそのまま評価される）。
+			update_option(
+				'vk_font_awesome_options',
+				array(
+					'version'       => $value['saved_version'],
+					'compatibility' => array(
+						'v4' => false,
+						'v5' => false,
+					),
+				)
+			);
+			$return = VkFontAwesomeVersions::current_info();
+			$this->assertEquals( $versions[ $value['expected_key'] ], $return, "current_info() failed for saved version: {$value['saved_version']}" );
+		}
+	}
 }

--- a/tests/test-vk-font-awesome-versions.php
+++ b/tests/test-vk-font-awesome-versions.php
@@ -194,53 +194,77 @@ class VkFontAwesomeVersionsTest extends WP_UnitTestCase {
 		// versions() の実キー配列を基準にして期待値を組み立てる（URL は環境依存のため直書きしない）。
 		$versions = VkFontAwesomeVersions::versions();
 
+		// 各ケースは vk_font_awesome_options に保存する生の値（stored）と、current_info() が返すべき versions() のキー（expected_key）を持つ。
+		// stored は current_info() が保存値を書き換えない読み取り専用のため、そのまま評価される。
 		$tests = array(
-			// 7 系 Web Fonts はそのまま 7_WebFonts_CSS のアセット情報を返す。
+			// --- 正常系 ---
 			array(
-				'saved_version' => '7_WebFonts_CSS',
-				'expected_key'  => '7_WebFonts_CSS',
+				'test_condition_name' => '保存値が 7 系 Web Fonts の場合 => 7_WebFonts_CSS のアセット情報を返す',
+				'stored'              => array(
+					'version'       => '7_WebFonts_CSS',
+					'compatibility' => array(),
+				),
+				'expected_key'        => '7_WebFonts_CSS',
 			),
-			// 7 系 SVG はそのまま 7_SVG_JS のアセット情報を返す。
 			array(
-				'saved_version' => '7_SVG_JS',
-				'expected_key'  => '7_SVG_JS',
+				'test_condition_name' => '保存値が 7 系 SVG の場合 => 7_SVG_JS のアセット情報を返す',
+				'stored'              => array(
+					'version'       => '7_SVG_JS',
+					'compatibility' => array(),
+				),
+				'expected_key'        => '7_SVG_JS',
 			),
-			// レガシー値（6 系）は versions() にキーが無いためデフォルト（7_WebFonts_CSS）へフォールバックする。
+			// --- 異常系・境界値（レガシー値／不正値／型不整合はデフォルトの 7_WebFonts_CSS へフォールバック） ---
 			array(
-				'saved_version' => '6_WebFonts_CSS',
-				'expected_key'  => '7_WebFonts_CSS',
+				'test_condition_name' => '保存値がレガシー値（6 系）の場合 => デフォルト 7_WebFonts_CSS へフォールバック',
+				'stored'              => array(
+					'version'       => '6_WebFonts_CSS',
+					'compatibility' => array(),
+				),
+				'expected_key'        => '7_WebFonts_CSS',
 			),
-			// レガシー値（5 系）も同様にフォールバックする。
 			array(
-				'saved_version' => '5_WebFonts_CSS',
-				'expected_key'  => '7_WebFonts_CSS',
+				'test_condition_name' => '保存値がレガシー値（5 系）の場合 => デフォルト 7_WebFonts_CSS へフォールバック',
+				'stored'              => array(
+					'version'       => '5_WebFonts_CSS',
+					'compatibility' => array(),
+				),
+				'expected_key'        => '7_WebFonts_CSS',
 			),
-			// レガシー値（4.7 系）も同様にフォールバックする。
 			array(
-				'saved_version' => '4.7',
-				'expected_key'  => '7_WebFonts_CSS',
+				'test_condition_name' => '保存値がレガシー値（4.7 系）の場合 => デフォルト 7_WebFonts_CSS へフォールバック',
+				'stored'              => array(
+					'version'       => '4.7',
+					'compatibility' => array(),
+				),
+				'expected_key'        => '7_WebFonts_CSS',
 			),
-			// 未知の不正な値もフォールバックする。
 			array(
-				'saved_version' => 'invalid_value',
-				'expected_key'  => '7_WebFonts_CSS',
+				'test_condition_name' => '保存値が未知の不正な文字列の場合 => デフォルト 7_WebFonts_CSS へフォールバック',
+				'stored'              => array(
+					'version'       => 'invalid_value',
+					'compatibility' => array(),
+				),
+				'expected_key'        => '7_WebFonts_CSS',
+			),
+			array(
+				'test_condition_name' => '保存値の配列に version キーが無い場合 => デフォルト 7_WebFonts_CSS へフォールバック',
+				'stored'              => array( 'compatibility' => array() ),
+				'expected_key'        => '7_WebFonts_CSS',
+			),
+			array(
+				'test_condition_name' => '保存値が配列でなく文字列（旧形式）の場合 => Fatal を起こさずデフォルト 7_WebFonts_CSS へフォールバック',
+				'stored'              => '6_WebFonts_CSS',
+				'expected_key'        => '7_WebFonts_CSS',
 			),
 		);
 
-		foreach ( $tests as $value ) {
-			// テスト対象のバージョンを保存する（current_info() は保存値を書き換えない読み取り専用のため、この値がそのまま評価される）。
-			update_option(
-				'vk_font_awesome_options',
-				array(
-					'version'       => $value['saved_version'],
-					'compatibility' => array(
-						'v4' => false,
-						'v5' => false,
-					),
-				)
-			);
+		foreach ( $tests as $case ) {
+			// テスト対象の値を保存する。
+			update_option( 'vk_font_awesome_options', $case['stored'] );
 			$return = VkFontAwesomeVersions::current_info();
-			$this->assertEquals( $versions[ $value['expected_key'] ], $return, "current_info() failed for saved version: {$value['saved_version']}" );
+			// 期待するアセット情報（versions() の該当キー）と一致することを確認する。
+			$this->assertEquals( $versions[ $case['expected_key'] ], $return, $case['test_condition_name'] );
 		}
 	}
 }

--- a/tests/test-vk-font-awesome-versions.php
+++ b/tests/test-vk-font-awesome-versions.php
@@ -194,6 +194,44 @@ class VkFontAwesomeVersionsTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test get_option_fa() : 旧 vk_font_awesome_version オプションの掃除
+	 *
+	 * 旧オプションが残っている場合、値を引き継いだか否かにかかわらず get_option_fa() 実行後に
+	 * 旧オプションが削除され、DB にスタール値が残らないことを確認する。
+	 *
+	 * @return void
+	 */
+	function test_get_option_fa_deletes_legacy_version_option() {
+		$tests = array(
+			array(
+				'test_condition_name' => '新形式に version が無く旧オプションだけある場合 => 旧オプションの値を引き継いで削除',
+				'new_option'          => array( 'compatibility' => array() ),
+				'legacy_version'      => '7_SVG_JS',
+				'expected_version'    => '7_SVG_JS',
+			),
+			array(
+				'test_condition_name' => '新形式が壊れたスカラー値かつ旧オプションもある場合 => デフォルトに寄せつつ旧オプションを削除',
+				'new_option'          => 'broken-scalar',
+				'legacy_version'      => '6_WebFonts_CSS',
+				'expected_version'    => '7_WebFonts_CSS',
+			),
+		);
+
+		foreach ( $tests as $case ) {
+			// 新旧両方のオプションをセットする。
+			update_option( 'vk_font_awesome_options', $case['new_option'] );
+			update_option( 'vk_font_awesome_version', $case['legacy_version'] );
+
+			$return = VkFontAwesomeVersions::get_option_fa();
+
+			// version が期待どおり解決されていること。
+			$this->assertEquals( $case['expected_version'], $return['version'], $case['test_condition_name'] );
+			// 旧オプションが削除されていること（get_option は未設定時 false を返す）。
+			$this->assertFalse( get_option( 'vk_font_awesome_version' ), $case['test_condition_name'] . '（旧オプション削除）' );
+		}
+	}
+
+	/**
 	 * Test current_info() method
 	 *
 	 * current_info() は get_option_fa() の正規化結果を基準にアセット情報を返す。

--- a/tests/test-vk-font-awesome-versions.php
+++ b/tests/test-vk-font-awesome-versions.php
@@ -185,8 +185,10 @@ class VkFontAwesomeVersionsTest extends WP_UnitTestCase {
 	/**
 	 * Test current_info() method
 	 *
-	 * 保存値に 4/5/6 系などのレガシー値や不正な値が入っていても Fatal を起こさず、
-	 * デフォルト（7 系 CSS）のアセット情報へフォールバックすることを確認する。
+	 * current_info() は get_option_fa() の正規化結果を基準にアセット情報を返す。
+	 * レガシー値（4/5/6 系）は 7 系（SVG / CSS の別を保持）へ解決され、
+	 * version キーが無い・配列・不正値など versions() に存在しないキーの場合は
+	 * Fatal を起こさず 7 系 CSS（7_WebFonts_CSS）へフォールバックすることを確認する。
 	 *
 	 * @return void
 	 */
@@ -195,9 +197,8 @@ class VkFontAwesomeVersionsTest extends WP_UnitTestCase {
 		$versions = VkFontAwesomeVersions::versions();
 
 		// 各ケースは vk_font_awesome_options に保存する生の値（stored）と、current_info() が返すべき versions() のキー（expected_key）を持つ。
-		// stored は current_info() が保存値を書き換えない読み取り専用のため、そのまま評価される。
 		$tests = array(
-			// --- 正常系 ---
+			// --- 正常系（7 系はそのまま解決） ---
 			array(
 				'test_condition_name' => '保存値が 7 系 Web Fonts の場合 => 7_WebFonts_CSS のアセット情報を返す',
 				'stored'              => array(
@@ -214,9 +215,9 @@ class VkFontAwesomeVersionsTest extends WP_UnitTestCase {
 				),
 				'expected_key'        => '7_SVG_JS',
 			),
-			// --- 異常系・境界値（レガシー値／不正値／型不整合はデフォルトの 7_WebFonts_CSS へフォールバック） ---
+			// --- レガシー値の移行（get_option_fa() 経由で 7 系へ。SVG / CSS の別は保持される） ---
 			array(
-				'test_condition_name' => '保存値がレガシー値（6 系）の場合 => デフォルト 7_WebFonts_CSS へフォールバック',
+				'test_condition_name' => '保存値がレガシー値（6 系 Web Fonts）の場合 => 7_WebFonts_CSS へ移行',
 				'stored'              => array(
 					'version'       => '6_WebFonts_CSS',
 					'compatibility' => array(),
@@ -224,7 +225,15 @@ class VkFontAwesomeVersionsTest extends WP_UnitTestCase {
 				'expected_key'        => '7_WebFonts_CSS',
 			),
 			array(
-				'test_condition_name' => '保存値がレガシー値（5 系）の場合 => デフォルト 7_WebFonts_CSS へフォールバック',
+				'test_condition_name' => '保存値がレガシー値（6 系 SVG）の場合 => 7_SVG_JS へ移行（CSS に寄せない）',
+				'stored'              => array(
+					'version'       => '6_SVG_JS',
+					'compatibility' => array(),
+				),
+				'expected_key'        => '7_SVG_JS',
+			),
+			array(
+				'test_condition_name' => '保存値がレガシー値（5 系 Web Fonts）の場合 => 7_WebFonts_CSS へ移行',
 				'stored'              => array(
 					'version'       => '5_WebFonts_CSS',
 					'compatibility' => array(),
@@ -232,15 +241,24 @@ class VkFontAwesomeVersionsTest extends WP_UnitTestCase {
 				'expected_key'        => '7_WebFonts_CSS',
 			),
 			array(
-				'test_condition_name' => '保存値がレガシー値（4.7 系）の場合 => デフォルト 7_WebFonts_CSS へフォールバック',
+				'test_condition_name' => '保存値がレガシー値（5 系 SVG）の場合 => 7_SVG_JS へ移行（CSS に寄せない）',
+				'stored'              => array(
+					'version'       => '5_SVG_JS',
+					'compatibility' => array(),
+				),
+				'expected_key'        => '7_SVG_JS',
+			),
+			array(
+				'test_condition_name' => '保存値がレガシー値（4.7 系）の場合 => 7_WebFonts_CSS へ移行',
 				'stored'              => array(
 					'version'       => '4.7',
 					'compatibility' => array(),
 				),
 				'expected_key'        => '7_WebFonts_CSS',
 			),
+			// --- 異常系・境界値（versions() に存在しないキーは Fatal を起こさず 7_WebFonts_CSS へフォールバック） ---
 			array(
-				'test_condition_name' => '保存値が未知の不正な文字列の場合 => デフォルト 7_WebFonts_CSS へフォールバック',
+				'test_condition_name' => '保存値が未知の不正な文字列の場合 => 7_WebFonts_CSS へフォールバック',
 				'stored'              => array(
 					'version'       => 'invalid_value',
 					'compatibility' => array(),
@@ -248,13 +266,16 @@ class VkFontAwesomeVersionsTest extends WP_UnitTestCase {
 				'expected_key'        => '7_WebFonts_CSS',
 			),
 			array(
-				'test_condition_name' => '保存値の配列に version キーが無い場合 => デフォルト 7_WebFonts_CSS へフォールバック',
+				'test_condition_name' => '保存値の配列に version キーが無い場合 => 7_WebFonts_CSS へフォールバック',
 				'stored'              => array( 'compatibility' => array() ),
 				'expected_key'        => '7_WebFonts_CSS',
 			),
 			array(
-				'test_condition_name' => '保存値が配列でなく文字列（旧形式）の場合 => Fatal を起こさずデフォルト 7_WebFonts_CSS へフォールバック',
-				'stored'              => '6_WebFonts_CSS',
+				'test_condition_name' => 'version の値が文字列でなく配列の場合 => Fatal を起こさず 7_WebFonts_CSS へフォールバック',
+				'stored'              => array(
+					'version'       => array( 'broken' ),
+					'compatibility' => array(),
+				),
 				'expected_key'        => '7_WebFonts_CSS',
 			),
 		);


### PR DESCRIPTION
## 概要

保存済みの `vk_font_awesome_options` の `version` が Font Awesome 7 系（`7_WebFonts_CSS` / `7_SVG_JS`）**以外**（`4.7` / 5 系 / 6 系などのレガシー値）の場合に、`current_info()` が PHP 8 で Fatal Error を起こし、フロント・管理画面ともに画面全体が表示不能（critical error / 真っ白）になる不具合を修正します。

## 原因

`current_info()` は保存値の `version` が 7 系以外だと `$option`（配列）を文字列キーへ変換できないまま `$versions[ $option ]` にアクセスしていました。

```php
if ( '7_WebFonts_CSS' === $option['version'] ) { $option = '7_WebFonts_CSS'; }
elseif ( '7_SVG_JS' === $option['version'] ) { $option = '7_SVG_JS'; }
// version が 6/5/4.7 系だとどちらにも該当せず $option は「配列のまま」
if ( empty( $versions[ $option ] ) ) { ... } // $versions[配列] → PHP 8 で Fatal
```

`versions()` は 7 系の 2 キーしか持たないため、レガシー値が保存されていると「7 系へフォールバック」する前に**配列を添字キーとしてアクセス**してしまい、`TypeError: Cannot access offset of type array in isset or empty` で落ちていました。

このライブラリは VK Blocks / Lightning などが同梱しており、過去に FA4/5/6 を選択して保存したまま 7 系のコードが動くと発生します。フォーラム報告（VK Blocks Pro 有効化で画面が文字化け／崩れる）の症状と一致します。

## 修正内容

- **`current_info()`**: バージョン解決を `get_option_fa()` の正規化結果に一本化。これによりレガシー値（4/5/6 系）は 7 系へ正しく移行され、**SVG / CSS の別も保持**される（5_SVG_JS / 6_SVG_JS → 7_SVG_JS）。呼び出し箇所（フロント / 管理画面 / エディタ）による解決差異も解消。
- **最終フォールバック**: `$versions` に存在しないキーの場合は、フィルタで上書き可能な `get_option_default()` ではなく、確実に存在する `'7_WebFonts_CSS'` 固定に寄せて未定義参照を排除。
- **`get_option_fa()`**: 保存値が配列でない・`version` キーが無い／文字列でない・`compatibility` が不正など、壊れた保存値が入っていても警告や Fatal を起こさないよう、マイグレーション処理の前後で値を正規化。

## 確認手順

### Before（修正前の再現）

1. このライブラリを同梱した WordPress で、オプションをレガシー値にする:
   ```
   wp option update vk_font_awesome_options --format=json '{"version":"6_WebFonts_CSS","compatibility":{"v4":false,"v5":false}}'
   ```
2. `current_info()` が走るページ（フロント表示や enqueue）を開く。
   → **HTTP 500 / `TypeError: Cannot access offset of type array` の Fatal Error で画面全体が表示不能**。

### After（修正後の確認）

1. 同じ手順でオプションを `6_WebFonts_CSS` / `6_SVG_JS` / `5_WebFonts_CSS` / `5_SVG_JS` / `4.7` / 不正値にする。
2. 同じページを開く。
   → **Fatal Error が発生せず、Web Fonts 系は 7_WebFonts_CSS、SVG 系は 7_SVG_JS のアセットで正常表示**。不正値・壊れた保存値は 7_WebFonts_CSS へフォールバック。

### 自動テスト

- `tests/test-vk-font-awesome-versions.php` に `test_current_info()` を追加。7 系はそのまま、レガシー値（4/5/6 系、SVG/CSS 別）は 7 系へ移行、version キー欠落・version が配列・不正値は 7_WebFonts_CSS へフォールバックすることを検証。
- 修正前コードではこのテストが同じ `TypeError` で失敗し、修正後は全テスト成功（`OK (4 tests, 27 assertions)`）することを確認済み。CI（PHP 7.4 / 8.2 / 8.3 × FA 6.8 / 6.9 / 7.0 の 9 ジョブ）も全て green。

## 影響範囲・後続対応

- 本修正は upstream ライブラリの修正です。マージ・タグ付け後、同梱側（VK Blocks Pro / Lightning 等）で本パッケージのバージョンを bump することで各プロダクトに反映されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * フォントアイコン設定が破損（配列でない等）していても、警告や致命的エラーが起きにくくなり、安全に情報を取得できるようになりました。
  * バージョン/互換性の欠落・不正値は正規化され、利用可能な既定へフォールバックします。併せて旧オプションは削除されます。
* **Tests**
  * 不正入力時の正規化・フォールバック、旧オプション削除、7系への最終フォールバックなどのケースを追加で検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->